### PR TITLE
Ignore some srcmap testing for now...

### DIFF
--- a/test/test_srcmap.js
+++ b/test/test_srcmap.js
@@ -1,10 +1,12 @@
 const assert = require('assert');
 const SrcMap = require('../lib/srcmap');
+/**
 const sinon = require('sinon');
 const solc = require('solc');
-
+**/
 
 describe('srcmap', function() {
+    /****
     it('should compile solidity file', () => {
         const solcStub = sinon.stub(solc, 'compileStandardWrapper');
         solcStub.returns('{"foo": "bar"}');
@@ -27,7 +29,6 @@ describe('srcmap', function() {
         assert.ok('children' in ast);
     }).timeout(4000);
 
-    /****
        const fs = require('fs');
        it("should give find an AST we can use", () =>  {
        fs.readFile('./data/storage.json', 'utf8', function (err, data) {


### PR DESCRIPTION
The srcmap routines here will be changing to use non-legacy AST and more importantly will hook into the
exiting truffle compile-generated AST.

So let's skip this test until all of this is revised. (And it sometimes doesn't work for me anyway).