### PR TITLE
Update Eslint parser 6 -> 8

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,7 @@ env:
   es6: true
 extends: 'eslint:recommended'
 parserOptions:
-  ecmaVersion: 6
+  ecmaVersion: 8
 rules:
   indent:
     - error


### PR DESCRIPTION
Updated Eslint parser to version 8 aka 2017.

Since we rely on async/await syntaxis and lowest supported
Node.js version is 8.x
Limitation on ES6 does not make sense anymore