### PR TITLE
Better error message handling?

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "5.2.0",
   "description": "Truffle run plugin to perform security analyses via MythX",
   "dependencies": {
-    "armlet": "~1.0.0",
+    "armlet": "~1.1.0",
     "configstore": "^4.0.0",
     "mocha": "^5.2.0",
     "proxyquire": "^2.1.0",


### PR DESCRIPTION
* Demark internal MythX errors better. Put *after* MythX report
* and don't print stack trace if there isn't one in an error message
* We should be using armlet 1.1.0 at least (1.2.0 is better though)